### PR TITLE
Proposed whitelist additions

### DIFF
--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -80,10 +80,9 @@ export function buildWhitelist() {
 
     String: {  // 21.2
       fromCharCode: j,
-      fromCodePoint: j,
       raw: j,                        // ES-Harmony
       prototype: {
-        codePointAt: j,
+        charCodeAt: j,
         endsWith: j,                 // ES-Harmony
         indexOf: j,
         lastIndexOf: j,
@@ -170,11 +169,11 @@ export function buildWhitelist() {
 
     Promise: {  // 25.4
       all: j,
-      catch: j,
       race: j,
       reject: j,
       resolve: j,
       prototype: {
+        catch: j,
         then: j,
       }
     }

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -80,12 +80,15 @@ export function buildWhitelist() {
 
     String: {  // 21.2
       fromCharCode: j,
+      fromCodePoint: j,
       raw: j,                        // ES-Harmony
       prototype: {
+        codePointAt: j,
         endsWith: j,                 // ES-Harmony
         indexOf: j,
         lastIndexOf: j,
         slice: j,
+        split: j,
         startsWith: j,               // ES-Harmony
       }
     },
@@ -94,11 +97,13 @@ export function buildWhitelist() {
 
     Array: {  // 22.1
       from: j,
+      isArray: j,
       of: j,                         // ES-Harmony?
       prototype: {
         filter: j,
         forEach: j,
         indexOf: j,
+        join: j,
         lastIndexOf: j,
         map: j,
         pop: j,
@@ -165,6 +170,7 @@ export function buildWhitelist() {
 
     Promise: {  // 25.4
       all: j,
+      catch: j,
       race: j,
       reject: j,
       resolve: j,


### PR DESCRIPTION
Hi @erights, I'm suggesting the following additions for the Jessie whitelist.

String.prototype.split (without regexp support) and Array.join should be straightforward to implement, and help avoid onerous looping.

Array.isArray has no equivalent in Jessie.

Promise.prototype.catch is heavily used.