### PR TITLE
fix(whitelist): bring up-to-date with a functional SES whitelist

### DIFF
--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -22,15 +22,21 @@ export function buildWhitelist() {
   "use strict";
 
   var j = true;  // included in the Jessie runtime
-
-  const whitelist = {
-    cajaVM: {                        // Caja support
-      Nat: j,
-      def: j,
-
-      confine: j,
+  
+  // These are necessary for most Javascript environments.
+  const anonIntrinsics = {
+    ThrowTypeError: {},
+    IteratorPrototype: {
+      next: '*',
+      constructor: false,
     },
+    ArrayIteratorPrototype: {},
+    StringIteratorPrototype: {},
+    MapIteratorPrototype: {},
+    SetIteratorPrototype: {},
+  };
 
+  const namedIntrinsics = {
     // In order according to
     // http://www.ecma-international.org/ecma-262/ with chapter
     // numbers where applicable
@@ -40,6 +46,8 @@ export function buildWhitelist() {
     Infinity: j,
     NaN: j,
     undefined: j,
+
+    eval: j, // realms-shim depends on having indirect eval in the globals
 
     // 19 Fundamental Objects
 
@@ -51,6 +59,11 @@ export function buildWhitelist() {
       entries: j,
       keys: j,
       values: j,
+      prototype: {
+        // We need to prefix __proto__ with ESCAPE so that it doesn't
+        // just change the prototype of this object.
+        ESCAPE__proto__: 'maybeAccessor',
+      },
     },
 
     Boolean: {  // 19.3
@@ -113,7 +126,7 @@ export function buildWhitelist() {
         reduce: j,
         reduceRight: j,
         slice: j,
-      }
+      },
     },
 
     // 23 Keyed Collections          all ES-Harmony
@@ -179,8 +192,8 @@ export function buildWhitelist() {
         catch: j,
         then: j,
       }
-    }
+    },
   };
 
-  return whitelist;
+  return {namedIntrinsics, anonIntrinsics};
 }

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -34,6 +34,9 @@ export function buildWhitelist() {
     StringIteratorPrototype: {},
     MapIteratorPrototype: {},
     SetIteratorPrototype: {},
+
+    GeneratorFunction: {},
+    AsyncGeneratorFunction: {},
   };
 
   const namedIntrinsics = {
@@ -60,9 +63,7 @@ export function buildWhitelist() {
       keys: j,
       values: j,
       prototype: {
-        // We need to prefix __proto__ with ESCAPE so that it doesn't
-        // just change the prototype of this object.
-        ESCAPE__proto__: 'maybeAccessor',
+        toString: '*',
       },
     },
 
@@ -105,6 +106,8 @@ export function buildWhitelist() {
         slice: j,
         split: j,
         startsWith: j,               // ES-Harmony
+
+        length: '*',
       }
     },
 
@@ -126,6 +129,9 @@ export function buildWhitelist() {
         reduce: j,
         reduceRight: j,
         slice: j,
+
+        // 22.1.4 instances
+        length: '*',
       },
     },
 


### PR DESCRIPTION
Note that optimizations/assumptions in `realms-shim/src/stdlib.js` prevent this
whitelist from deleting globals like `isFinite`, but the whitelist
should work when this limitation is fixed.
